### PR TITLE
Feature/tls

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.4
 MAINTAINER Chris Dornsife <chris@applariat.com>
 
-RUN apk add --no-cache postfix rsyslog supervisor \
+RUN apk add --no-cache ca-certificates postfix rsyslog supervisor \
     && /usr/bin/newaliases
 
 COPY . /

--- a/image/tx-smtp-relay.sh
+++ b/image/tx-smtp-relay.sh
@@ -28,4 +28,10 @@ postconf 'smtputf8_enable = no' || exit 1
 # This makes sure the message id is set. If this is set to no dkim=fail will happen.
 postconf 'always_add_missing_headers = yes' || exit 1
 
+# TLS
+postconf "smtp_use_tls = yes" || exit 1
+postconf "smtp_tls_security_level = encrypt" || exit 1
+postconf "smtp_tls_note_starttls_offer = yes" || exit 1
+postconf -e 'smtp_tls_CAfile = /etc/ssl/certs/ca-certificates.crt' || exit 1
+
 /usr/bin/supervisord -n


### PR DESCRIPTION
Enable TLS on the SMTP sidecar.

I've checked that this works with both SendGrid and AWS SES.

Is it necessary to have some sort of environment variable to flag for this feature to be enabled?  i.e. are there some configurations where this won't be compatible?