### PR TITLE
Feature/specify port

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,16 @@ We needed a simple docker image that can be configured with env vars. Also, the 
 Run on docker
 ```
 docker run --rm -it -p 2525:25 \
-	-e TX_SMTP_RELAY_HOST="[smtp.sendgrid.net]:587" \
+	-e TX_SMTP_RELAY_HOST="smtp.sendgrid.net" \
+        -e TX_SMTP_RELAY_PORT=25 \
 	-e TX_SMTP_RELAY_MYHOSTNAME=tx-smtp-relay.yourhost.com \
 	-e TX_SMTP_RELAY_USERNAME=username \
 	-e TX_SMTP_RELAY_PASSWORD=password \
 	applariat/tx-smtp-relay
 
 ```
+Note that all parameters except TX_SMTP_RELAY_PORT are required.  The default value for the port is 25.
+
 Send a test message
 <pre>
 <b>telnet localhost 2525</b>

--- a/README.md
+++ b/README.md
@@ -12,13 +12,14 @@ Run on docker
 ```
 docker run --rm -it -p 2525:25 \
 	-e TX_SMTP_RELAY_HOST="smtp.sendgrid.net" \
-        -e TX_SMTP_RELAY_PORT=25 \
+	-e TX_SMTP_RELAY_PORT=25 \
 	-e TX_SMTP_RELAY_MYHOSTNAME=tx-smtp-relay.yourhost.com \
 	-e TX_SMTP_RELAY_USERNAME=username \
 	-e TX_SMTP_RELAY_PASSWORD=password \
 	applariat/tx-smtp-relay
 
 ```
+
 Note that all parameters except TX_SMTP_RELAY_PORT are required.  The default value for the port is 25.
 
 Send a test message

--- a/image/tx-smtp-relay.sh
+++ b/image/tx-smtp-relay.sh
@@ -5,6 +5,12 @@ TX_SMTP_RELAY_MYHOSTNAME=${TX_SMTP_RELAY_MYHOSTNAME?Missing env var TX_SMTP_RELA
 TX_SMTP_RELAY_USERNAME=${TX_SMTP_RELAY_USERNAME?Missing env var TX_SMTP_RELAY_USERNAME}
 TX_SMTP_RELAY_PASSWORD=${TX_SMTP_RELAY_PASSWORD?Missing env var TX_SMTP_RELAY_PASSWORD}
 
+# Port is set to 25 by default unless specifically set
+TX_SMTP_RELAY_PORT=${TX_SMTP_RELAY_PORT:-25}
+
+# Put host/port into postconf format
+TX_SMTP_RELAY_HOST="[${TX_SMTP_RELAY_HOST}]:${TX_SMTP_RELAY_PORT}"
+
 
 # handle sasl
 echo "${TX_SMTP_RELAY_HOST} ${TX_SMTP_RELAY_USERNAME}:${TX_SMTP_RELAY_PASSWORD}" > /etc/postfix/sasl_passwd || exit 1


### PR DESCRIPTION
This PR allows the specification of the SMTP server port number in a separate environment variable.  It was originally specified as part of the TX_SMTP_RELAY_HOST variable, which made it inflexible for the purposes of properly constructing k8s secrets.

This has been tested on Dev and is working.