### PR TITLE
Ryver #SYS-545: Security upgrade to Alpine 3.14.3

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.14.3
 MAINTAINER Chris Dornsife <chris@applariat.com>
 
 RUN apk add --no-cache ca-certificates postfix rsyslog supervisor \

--- a/image/tx-smtp-relay.sh
+++ b/image/tx-smtp-relay.sh
@@ -18,7 +18,7 @@ postmap /etc/postfix/sasl_passwd || exit 1
 rm /etc/postfix/sasl_passwd || exit 1
 
 postconf 'smtp_sasl_auth_enable = yes' || exit 1
-postconf 'smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd' || exit 1
+postconf 'smtp_sasl_password_maps = lmdb:/etc/postfix/sasl_passwd' || exit 1
 postconf 'smtp_sasl_security_options =' || exit 1
 
 # These are required.


### PR DESCRIPTION
Security upgrade to Alpine 3.14.3.

A configuration change is required due to changes in the postfix version.

The solution in the end was very simple, and detailed here: https://gitlab.alpinelinux.org/alpine/aports/-/issues/12381

This was tested in Dev and I managed to send an email to my inbox.

1. Go to contact-ag.dev.greens.systems
2. Go to Civi - https://contact-ag.dev.greens.systems/civicrm/admin/setting/smtp?reset=1
3. Press Save and Send Test Email
4. The test email was successfully received in my inbox.