### PR TITLE
Update base alpine image to 3.16

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14.3
+FROM alpine:3.16
 MAINTAINER Chris Dornsife <chris@applariat.com>
 
 RUN apk add --no-cache ca-certificates postfix rsyslog supervisor \


### PR DESCRIPTION
This PR updates the base version of Alpine Linux to 3.16 to address several known vulnerabilities.